### PR TITLE
Log exception filter changes

### DIFF
--- a/src/Georadix.WebApi/Filters/CheckArgumentsForNullAttribute.cs
+++ b/src/Georadix.WebApi/Filters/CheckArgumentsForNullAttribute.cs
@@ -7,7 +7,6 @@
     using System.Net.Http;
     using System.Web.Http.Controllers;
     using System.Web.Http.Filters;
-    using System.Web.Http.ModelBinding;
 
     /// <summary>
     /// Represents a filter attribute used to check if the arguments are null.

--- a/src/Georadix.WebApi/Filters/LogExceptionFilterAttribute.cs
+++ b/src/Georadix.WebApi/Filters/LogExceptionFilterAttribute.cs
@@ -1,15 +1,12 @@
 ﻿namespace Georadix.WebApi.Filters
 {
-    using Georadix.WebApi.Resources;
     using log4net;
     using System;
-    using System.Net;
-    using System.Net.Http;
     using System.Web.Http;
     using System.Web.Http.Filters;
 
     /// <summary>
-    /// Logs exception and returns a standard HTTP 500 status code.
+    /// Represents a filter attribute that logs unhandled exceptions in the execution.
     /// </summary>
     public class LogExceptionFilterAttribute : ExceptionFilterAttribute
     {
@@ -43,9 +40,6 @@
                     actionExecutedContext.ActionContext.ControllerContext.Controller.GetType());
 
                 logger.Error(baseException.Message, baseException);
-
-                actionExecutedContext.Response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
-                actionExecutedContext.Response.Content = new StringContent(InvariantStrings.ErrorProcessingRequest);
             }
         }
     }

--- a/src/Georadix.WebApi/Filters/ValidateModelAttribute.cs
+++ b/src/Georadix.WebApi/Filters/ValidateModelAttribute.cs
@@ -6,7 +6,7 @@
     using System.Web.Http.Filters;
 
     /// <summary>
-    /// An attribute to automatically validate model with Web API.
+    /// Represents a filter attribute that validates models used within a Web API.
     /// </summary>
     public class ValidateModelAttribute : ActionFilterAttribute
     {


### PR DESCRIPTION
Since Web API error detail can be set using the `HttpConfiguration.IncludeErrorDetailPolicy` property, it would be best for this filter not to specify one. At it stands, whatever is specified in the above property is effectively ignored.